### PR TITLE
Version bump

### DIFF
--- a/BazaarPlannerModInstaller/Program.cs
+++ b/BazaarPlannerModInstaller/Program.cs
@@ -10,7 +10,7 @@ namespace BazaarPlannerModInstaller
     {
         private const string DOTNET_DOWNLOAD_URL = "https://download.visualstudio.microsoft.com/download/pr/f18288f6-1732-415b-b577-7fb46510479a/a98239f751a7aed31bc4aa12f348a9bf/windowsdesktop-runtime-8.0.2-win-x64.exe";
         private const string GITHUB_API_URL = "https://api.github.com/repos/oceanseth/BazaarPlannerMod/releases/latest";
-        private const string CURRENT_VERSION = "1.0.2"; // Update this with your current version
+        private const string CURRENT_VERSION = "1.0.3"; // Update this with your current version
 
         [STAThread]
         static void Main()


### PR DESCRIPTION
Installer detects that version 1.0.3 is available, but fails to see that it itself is the 1.0.3 installer